### PR TITLE
Refactor: misc contracts

### DIFF
--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -303,7 +303,7 @@ contract ShortOTokenActionWithSwap is IAction, OwnableUpgradeable, AirswapBase, 
    * @dev funtion to check that the otoken being sold meets a minimum valid strike price
    * this hook is triggered in the _customOtokenCheck function. 
    */
-  function _isValidStrike(uint256 strikePrice) internal view returns (bool) {
+  function _isValidStrike(uint256) internal pure returns (bool) {
     // // TODO: override with your filler code. 
     // uint256 spotPrice = oracle.getPrice(address(weth));
     // // checks that the strike price set is > than 105% of current price

--- a/contracts/core/OpynPerpVault.sol
+++ b/contracts/core/OpynPerpVault.sol
@@ -89,11 +89,10 @@ contract OpynPerpVault is ERC20, ReentrancyGuard, Ownable {
   constructor (
     address _sdToken,
     address _curve,
-    address _owner,
     address _feeRecipient,
     string memory _tokenName,
     string memory _tokenSymbol
-    ) ERC20(_tokenName, _tokenSymbol) public {     
+    ) ERC20(_tokenName, _tokenSymbol) {
     sdToken = _sdToken;
     feeRecipient = _feeRecipient;
     curve = ICurve(_curve);

--- a/contracts/mocks/MockAction.sol
+++ b/contracts/mocks/MockAction.sol
@@ -34,7 +34,7 @@ contract MockAction is IAction() {
    * The function for the vault to call at the end of each vault's round.
    * after calling this function, the vault will try to pull assets back from the action and enable withdraw.
    */
-  function closePosition() external override  {
+  function closePosition() external view override  {
     require(msg.sender == vault, "MockAction: sender is not vault");
     // uint256 balance = IERC20(asset).balanceOf(address(this));
   }

--- a/contracts/mocks/MockController.sol
+++ b/contracts/mocks/MockController.sol
@@ -57,7 +57,7 @@ contract MockController {
 
   function isSettlementAllowed(
     address /*otoken*/
-  ) external view returns (bool) {
+  ) external pure returns (bool) {
     return true;
   }
 

--- a/contracts/mocks/MockCurve.sol
+++ b/contracts/mocks/MockCurve.sol
@@ -14,16 +14,16 @@ contract MockCurve {
         ecrv = MockERC20(_ecrv);
     }
 
-    function add_liquidity(uint256[2] memory amounts, uint256 minAmount) external payable returns (uint256) { 
+    function add_liquidity(uint256[2] memory amounts, uint256) external payable returns (uint256) {
         ecrv.mint(msg.sender, amounts[0]);
         return amounts[0];
     }
 
-    function get_virtual_price() external returns (uint256) { 
+    function get_virtual_price() external pure returns (uint256) {
         return 1 ether; 
     }
 
-    function remove_liquidity_one_coin(uint256 amount, int128 index, uint256 min) external returns (uint256) { 
+    function remove_liquidity_one_coin(uint256 amount, int128, uint256) external returns (uint256) {
         ecrv.burn(msg.sender, amount);
         (bool success, ) = (msg.sender).call{ value: amount }('');
         require(success, 'ETH transfer failed');

--- a/contracts/mocks/MockStakedao.sol
+++ b/contracts/mocks/MockStakedao.sol
@@ -26,11 +26,11 @@ contract MockStakedao is ERC20PermitUpgradeable {
       mint(msg.sender, amount);
   }
 
-  function getPricePerFullShare() external returns (uint256) {
+  function getPricePerFullShare() external pure returns (uint256) {
       return 1 ether;
   }
 
-  function token () public returns (address) {
+  function token () public view returns (address) {
       return ecrv;
   }
 

--- a/contracts/mocks/MockWhitelist.sol
+++ b/contracts/mocks/MockWhitelist.sol
@@ -19,15 +19,15 @@ contract MockWhitelist is IWhitelist{
     return isWhitelisted;
   }
 
-  function whitelistCollateral(address _collateral) external override {
+  function whitelistCollateral(address) external override {
     isWhitelisted = true;
   }
 
   function whitelistProduct(
-    address _underlying,
-    address _strike,
-    address _collateral,
-    bool _isPut
+    address,
+    address,
+    address,
+    bool
   ) external override {
     isWhitelistedProduct = true;
   }

--- a/contracts/utils/StakedaoEcrvPricer.sol
+++ b/contracts/utils/StakedaoEcrvPricer.sol
@@ -36,7 +36,7 @@ contract StakedaoEcrvPricer {
         address _underlying,
         address _oracle, 
         address _curve
-    ) public {
+    ) {
         require(_lpToken != address(0), "StakeDaoPricer: lpToken address can not be 0");
         require(_underlying != address(0), "StakeDaoPricer: underlying address can not be 0");
         require(_oracle != address(0), "StakeDaoPricer: oracle address can not be 0");
@@ -84,7 +84,7 @@ contract StakedaoEcrvPricer {
         return pricePerShare.mul(_underlyingPrice).mul(curvePrice).div(10**uint256(2 * underlyingDecimals));
     }
 
-    function getHistoricalPrice(uint80 _roundId) external view returns (uint256, uint256) {
+    function getHistoricalPrice(uint80) external pure returns (uint256, uint256) {
         revert("StakeDaoPricer: Deprecated");
     }
 }

--- a/test/mainnet-fork/short-vault.ts
+++ b/test/mainnet-fork/short-vault.ts
@@ -130,7 +130,6 @@ describe('Mainnet Fork Tests', function() {
     vault = (await VaultContract.deploy(
       stakeDaoTokenAddress,
       curveAddress,
-      owner.address,
       feeRecipient.address,
       'OpynPerpShortVault share',
       'sOPS',

--- a/test/unit-tests/OpynPerpVault.ts
+++ b/test/unit-tests/OpynPerpVault.ts
@@ -68,7 +68,6 @@ describe('OpynPerpVault Tests', function () {
     vault = (await VaultContract.deploy(
       sdecrv.address,
       curve.address,
-      owner.address,
       feeRecipient.address,
       'OpynPerpShortVault share',
       'sOPS'


### PR DESCRIPTION
- refactor: visibility for constructors deprecated
- refactor: remove variable names for unused function parameters
- refactor: restrict function state mutability to `pure`
- refactor: restrict function state mutability to `view`