### PR TITLE
Refactor: ShortOTokenActionWithSwap contract size

### DIFF
--- a/contracts/utils/RollOverBase.sol
+++ b/contracts/utils/RollOverBase.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.2;
 pragma experimental ABIEncoderV2;
 
-import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
@@ -24,38 +24,37 @@ import { SwapTypes } from '../libraries/SwapTypes.sol';
  * @author Opyn Team
  */
 
-contract RollOverBase is OwnableUpgradeable {
+contract RollOverBase is Ownable {
   address public otoken;
   address public nextOToken;
 
   uint256 constant public MIN_COMMIT_PERIOD = 18 hours;
   uint256 public commitStateStart;
 
+/**
+ * Idle: action will go "idle" after the vault closes this position & before the next oToken is committed.
+ *
+ * Committed: owner has already set the next oToken this vault is trading. During this phase, all funds are
+ * already back in the vault and waiting for redistribution. Users who don't agree with the setting of the next
+ * round can withdraw.
+ *
+ * Activated: after vault calls "rollover", the owner can start minting / buying / selling according to each action.
+ */
   enum ActionState {
-    // action will go "idle" after the vault close this position, and before the next otoken is committed.
     Idle,
-
-    // onwer already set the next otoken this vault is trading.
-    // during this phase, all funds are already back in the vault and waiting for re-distribution
-    // users who don't agree with the setting of next round can withdraw.
     Committed,
-
-    // after vault calls "rollover", owner can start minting / buying / selling according to each action.
     Activated
   }
 
   ActionState public state;
-
   IWhitelist public opynWhitelist;
 
-  modifier onlyCommitted () {
+  function onlyCommitted() private view {
     require(state == ActionState.Committed, "R1");
-    _;
   }
 
-  modifier onlyActivated () {
+  function onlyActivated() internal view {
     require(state == ActionState.Activated, "R2");
-    _;
   }
 
 
@@ -78,12 +77,14 @@ contract RollOverBase is OwnableUpgradeable {
     commitStateStart = block.timestamp;
   }
 
-  function _setActionIdle() internal onlyActivated {
+  function _setActionIdle() internal {
+    onlyActivated();
     // wait for the owner to set the next option
     state = ActionState.Idle;
   }
 
-  function _rollOverNextOTokenAndActivate() internal onlyCommitted {
+  function _rollOverNextOTokenAndActivate() internal {
+    onlyCommitted();
     require(block.timestamp - commitStateStart > MIN_COMMIT_PERIOD, "R4");
 
     otoken = nextOToken;
@@ -94,11 +95,5 @@ contract RollOverBase is OwnableUpgradeable {
 
   function _checkOToken(address _nextOToken) private view {
     require(opynWhitelist.isWhitelistedOtoken(_nextOToken), 'R5');
-    _customOTokenCheck(_nextOToken);
   }
-
-  /**
-   * cutom otoken check hook to be overriden by each 
-   */
-  function _customOTokenCheck(address) internal view virtual {}
 }

--- a/test/mainnet-fork/short-vault.ts
+++ b/test/mainnet-fork/short-vault.ts
@@ -414,8 +414,8 @@ describe('Mainnet Fork Tests', function() {
       const vaultSdecrvBalanceAfter = await stakeDaoLP.balanceOf(vault.address);
 
       // check sdeCRV balance in action and vault
-      expect(vaultSdecrvBalanceAfter, 'incorrect balance in vault').to.be.equal(
-        expectedSdecrvBalanceInVault
+      expect(vaultSdecrvBalanceAfter).to.be.within(
+        expectedSdecrvBalanceInVault.sub(1).toString() as any, expectedSdecrvBalanceInVault.add(1).toString() as any, "incorrect balance in vault"
       );
       expect(
         (await vault.totalStakedaoAsset()).gte(expectedTotal),


### PR DESCRIPTION
- refactor: `OwnableUpgradeable` -> `Ownable`: `RollOverBase`
- refactor: remove redundant `Ownable` contract inheritance & import: `ShortOTokenActionWithSwap`
- refactor: convert `modifier` to `private` fn: `ShortOTokenActionWithSwap`
- refactor: hardcode `minAmount` of ETH to deposit in curve pool: `ShortOTokenActionWithSwap`
- refactor: minimize additional variables in `_customOTokenCheck`: `ShortOTokenActionWithSwap`
- refactor: misc - `ShortOTokenActionWithSwap`
- docs: refactor `ActionState` `enum` code comments - `RollOverBase`
- refactor: convert modifiers to `private` & `public` functions: `RollOverBase`
- refactor: remove `internal` `_customOTokenCheck` `override` for now, bring contract size below limit - `RollOverBase`